### PR TITLE
Etc2 t h scalar decoding support

### DIFF
--- a/BlockData.cpp
+++ b/BlockData.cpp
@@ -307,202 +307,202 @@ static etcpak_force_inline int32_t expand7(uint32_t value)
     return (value << 1) | (value >> 6);
 }
 
-static etcpak_force_inline void DecodeT(uint64_t block, uint32_t* dst, uint32_t w)
+static etcpak_force_inline void DecodeT( uint64_t block, uint32_t* dst, uint32_t w )
 {
-    const auto r0 = (block >> 24) & 0x1B;
-    const auto rh0 = (r0 >> 3) & 0x3;
+    const auto r0 = ( block >> 24 ) & 0x1B;
+    const auto rh0 = ( r0 >> 3 ) & 0x3;
     const auto rl0 = r0 & 0x3;
-    const auto g0 = (block >> 20) & 0xF;
-    const auto b0 = (block >> 16) & 0xF;
+    const auto g0 = ( block >> 20 ) & 0xF;
+    const auto b0 = ( block >> 16 ) & 0xF;
 
-    const auto r1 = (block >> 12) & 0xF;
-    const auto g1 = (block >> 8) & 0xF;
-    const auto b1 = (block >> 4) & 0xF;
+    const auto r1 = ( block >> 12 ) & 0xF;
+    const auto g1 = ( block >> 8 ) & 0xF;
+    const auto b1 = ( block >> 4 ) & 0xF;
 
-    const auto cr0 = ((rh0 << 6) | (rl0 << 4) | (rh0 << 2) | rl0);
-    const auto cg0 = (g0 << 4) | g0;
-    const auto cb0 = (b0 << 4) | b0;
+    const auto cr0 = ( ( rh0 << 6 ) | ( rl0 << 4 ) | ( rh0 << 2 ) | rl0);
+    const auto cg0 = ( g0 << 4 ) | g0;
+    const auto cb0 = ( b0 << 4 ) | b0;
 
-    const auto cr1 = (r1 << 4) | r1;
-    const auto cg1 = (g1 << 4) | g1;
-    const auto cb1 = (b1 << 4) | b1;
+    const auto cr1 = ( r1 << 4 ) | r1;
+    const auto cg1 = ( g1 << 4 ) | g1;
+    const auto cb1 = ( b1 << 4 ) | b1;
 
-    const auto codeword_hi = (block >> 2) & 0x3;
+    const auto codeword_hi = ( block >> 2 ) & 0x3;
     const auto codeword_lo = block & 0x1;
-    const auto codeword = (codeword_hi << 1) | codeword_lo;
+    const auto codeword = ( codeword_hi << 1 ) | codeword_lo;
 
-    const auto c2r = clampu8(cr1 + table59T58H[codeword]);
-    const auto c2g = clampu8(cg1 + table59T58H[codeword]);
-    const auto c2b = clampu8(cb1 + table59T58H[codeword]);
+    const auto c2r = clampu8( cr1 + table59T58H[codeword] );
+    const auto c2g = clampu8( cg1 + table59T58H[codeword] );
+    const auto c2b = clampu8( cb1 + table59T58H[codeword] );
 
-    const auto c3r = clampu8(cr1 - table59T58H[codeword]);
-    const auto c3g = clampu8(cg1 - table59T58H[codeword]);
-    const auto c3b = clampu8(cb1 - table59T58H[codeword]);
+    const auto c3r = clampu8( cr1 - table59T58H[codeword] );
+    const auto c3g = clampu8( cg1 - table59T58H[codeword] );
+    const auto c3b = clampu8( cb1 - table59T58H[codeword] );
 
     const uint32_t col_tab[4] = {
-        cr0 | (cg0 << 8) | (cb0 << 16) | 0xFF000000,
-        c2r | (c2g << 8) | (c2b << 16) | 0xFF000000,
-        cr1 | (cg1 << 8) | (cb1 << 16) | 0xFF000000,
-        c3r | (c3g << 8) | (c3b << 16) | 0xFF000000
+        cr0 | ( cg0 << 8 ) | ( cb0 << 16 ) | 0xFF000000,
+        c2r | ( c2g << 8 ) | ( c2b << 16 ) | 0xFF000000,
+        cr1 | ( cg1 << 8 ) | ( cb1 << 16 ) | 0xFF000000,
+        c3r | ( c3g << 8 ) | ( c3b << 16 ) | 0xFF000000
     };
 
-    const uint32_t indexes = (block >> 32) & 0xFFFFFFFF;
-    for (uint8_t j = 0; j < 4; j++)
+    const uint32_t indexes = ( block >> 32 ) & 0xFFFFFFFF;
+    for( uint8_t j = 0; j < 4; j++ )
     {
-        for (uint8_t i = 0; i < 4; i++)
+        for( uint8_t i = 0; i < 4; i++ )
         {
             //2bit indices distributed on two lane 16bit numbers
-            const uint8_t index = (((indexes >> (j + i * 4 + 16)) & 0x1) << 1) | ((indexes >> (j + i * 4)) & 0x1);
+            const uint8_t index = ( ( ( indexes >> ( j + i * 4 + 16 ) ) & 0x1 ) << 1) | ( ( indexes >> ( j + i * 4 ) ) & 0x1);
             dst[j * w + i] = col_tab[index];
         }
     }
 }
 
-static etcpak_force_inline void DecodeTAlpha(uint64_t block, uint64_t alpha, uint32_t* dst, uint32_t w)
+static etcpak_force_inline void DecodeTAlpha( uint64_t block, uint64_t alpha, uint32_t* dst, uint32_t w )
 {
-    const auto r0 = (block >> 24) & 0x1B;
-    const auto rh0 = (r0 >> 3) & 0x3;
+    const auto r0 = ( block >> 24 ) & 0x1B;
+    const auto rh0 = ( r0 >> 3 ) & 0x3;
     const auto rl0 = r0 & 0x3;
-    const auto g0 = (block >> 20) & 0xF;
-    const auto b0 = (block >> 16) & 0xF;
+    const auto g0 = ( block >> 20 ) & 0xF;
+    const auto b0 = ( block >> 16 ) & 0xF;
 
-    const auto r1 = (block >> 12) & 0xF;
-    const auto g1 = (block >> 8) & 0xF;
-    const auto b1 = (block >> 4) & 0xF;
+    const auto r1 = ( block >> 12 ) & 0xF;
+    const auto g1 = ( block >> 8 ) & 0xF;
+    const auto b1 = ( block >> 4 ) & 0xF;
 
-    const auto cr0 = ((rh0 << 6) | (rl0 << 4) | (rh0 << 2) | rl0);
-    const auto cg0 = (g0 << 4) | g0;
-    const auto cb0 = (b0 << 4) | b0;
+    const auto cr0 = ( ( rh0 << 6 ) | ( rl0 << 4 ) | ( rh0 << 2 ) | rl0);
+    const auto cg0 = ( g0 << 4 ) | g0;
+    const auto cb0 = ( b0 << 4 ) | b0;
 
-    const auto cr1 = (r1 << 4) | r1;
-    const auto cg1 = (g1 << 4) | g1;
-    const auto cb1 = (b1 << 4) | b1;
+    const auto cr1 = ( r1 << 4 ) | r1;
+    const auto cg1 = ( g1 << 4 ) | g1;
+    const auto cb1 = ( b1 << 4 ) | b1;
 
-    const auto codeword_hi = (block >> 2) & 0x3;
+    const auto codeword_hi = ( block >> 2 ) & 0x3;
     const auto codeword_lo = block & 0x1;
     const auto codeword = (codeword_hi << 1) | codeword_lo;
 
     const int32_t base = alpha >> 56;
-    const int32_t mul = (alpha >> 52) & 0xF;
-    const auto tbl = g_alpha[(alpha >> 48) & 0xF];
+    const int32_t mul = ( alpha >> 52 ) & 0xF;
+    const auto tbl = g_alpha[( alpha >> 48 ) & 0xF];
 
-    const auto c2r = clampu8(cr1 + table59T58H[codeword]);
-    const auto c2g = clampu8(cg1 + table59T58H[codeword]);
-    const auto c2b = clampu8(cb1 + table59T58H[codeword]);
+    const auto c2r = clampu8( cr1 + table59T58H[codeword] );
+    const auto c2g = clampu8( cg1 + table59T58H[codeword] );
+    const auto c2b = clampu8( cb1 + table59T58H[codeword] );
 
-    const auto c3r = clampu8(cr1 - table59T58H[codeword]);
-    const auto c3g = clampu8(cg1 - table59T58H[codeword]);
-    const auto c3b = clampu8(cb1 - table59T58H[codeword]);
+    const auto c3r = clampu8( cr1 - table59T58H[codeword] );
+    const auto c3g = clampu8( cg1 - table59T58H[codeword] );
+    const auto c3b = clampu8( cb1 - table59T58H[codeword] );
 
     const uint32_t col_tab[4] = {
-        cr0 | (cg0 << 8) | (cb0 << 16),
-        c2r | (c2g << 8) | (c2b << 16),
-        cr1 | (cg1 << 8) | (cb1 << 16),
-        c3r | (c3g << 8) | (c3b << 16)
+        cr0 | ( cg0 << 8 ) | ( cb0 << 16 ),
+        c2r | ( c2g << 8 ) | ( c2b << 16 ),
+        cr1 | ( cg1 << 8 ) | ( cb1 << 16 ),
+        c3r | ( c3g << 8 ) | ( c3b << 16 )
     };
 
-    const uint32_t indexes = (block >> 32) & 0xFFFFFFFF;
-    for (uint8_t j = 0; j < 4; j++)
+    const uint32_t indexes = ( block >> 32 ) & 0xFFFFFFFF;
+    for( uint8_t j = 0; j < 4; j++ )
     {
-        for (uint8_t i = 0; i < 4; i++)
+        for( uint8_t i = 0; i < 4; i++ )
         {
             //2bit indices distributed on two lane 16bit numbers
-            const uint8_t index = (((indexes >> (j + i * 4 + 16)) & 0x1) << 1) | ((indexes >> (j + i * 4)) & 0x1);
-            const auto amod = tbl[(alpha >> (45 - j * 3 - i * 12)) & 0x7];
-            const uint32_t a = clampu8(base + amod * mul);
-            dst[j * w + i] = col_tab[index] | (a << 24);
+            const uint8_t index = ( ( ( indexes >> ( j + i * 4 + 16 ) ) & 0x1 ) << 1 ) | ( ( indexes >> ( j + i * 4 ) ) & 0x1 );
+            const auto amod = tbl[( alpha >> ( 45 - j * 3 - i * 12 ) ) & 0x7];
+            const uint32_t a = clampu8( base + amod * mul );
+            dst[j * w + i] = col_tab[index] | ( a << 24 );
         }
     }
 }
 
-static etcpak_force_inline void DecodeH(uint64_t block, uint32_t* dst, uint32_t w)
+static etcpak_force_inline void DecodeH( uint64_t block, uint32_t* dst, uint32_t w )
 {
-    const uint32_t indexes = (block >> 32) & 0xFFFFFFFF;
+    const uint32_t indexes = ( block >> 32 ) & 0xFFFFFFFF;
 
-    const auto r0444 = (block >> 27) & 0xF;
-    const auto g0444 = ((block >> 20) & 0x1) | (((block >> 24) & 0x7) << 1);
-    const auto b0444 = ((block >> 15) & 0x7) | (((block >> 19) & 0x1) << 3);
+    const auto r0444 = ( block >> 27 ) & 0xF;
+    const auto g0444 = ( ( block >> 20 ) & 0x1 ) | ( ( ( block >> 24 ) & 0x7 ) << 1 );
+    const auto b0444 = ( ( block >> 15 ) & 0x7 ) | ( ( ( block >> 19 ) & 0x1 ) << 3 );
 
-    const auto r1444 = (block >> 11) & 0xF;
-    const auto g1444 = (block >> 7) & 0xF;
-    const auto b1444 = (block >> 3) & 0xF;
+    const auto r1444 = ( block >> 11 ) & 0xF;
+    const auto g1444 = ( block >> 7 ) & 0xF;
+    const auto b1444 = ( block >> 3 ) & 0xF;
 
-    const auto r0 = (r0444 << 4) | r0444;
-    const auto g0 = (g0444 << 4) | g0444;
-    const auto b0 = (b0444 << 4) | b0444;
+    const auto r0 = ( r0444 << 4 ) | r0444;
+    const auto g0 = ( g0444 << 4 ) | g0444;
+    const auto b0 = ( b0444 << 4 ) | b0444;
 
-    const auto r1 = (r1444 << 4) | r1444;
-    const auto g1 = (g1444 << 4) | g1444;
-    const auto b1 = (b1444 << 4) | b1444;
+    const auto r1 = ( r1444 << 4 ) | r1444;
+    const auto g1 = ( g1444 << 4 ) | g1444;
+    const auto b1 = ( b1444 << 4 ) | b1444;
 
-    const auto codeword_hi = ((block & 0x1) << 1) | ((block & 0x4));
-    const auto c0 = (r0444 << 8) | (g0444 << 4) | (b0444 << 0);
-    const auto c1 = (block >> 3) & ((1 << 12) - 1);
-    const auto codeword_lo = (c0 >= c1) ? 1 : 0;
+    const auto codeword_hi = ( ( block & 0x1 ) << 1 ) | ( ( block & 0x4 ) );
+    const auto c0 = ( r0444 << 8 ) | ( g0444 << 4 ) | ( b0444 << 0 );
+    const auto c1 = ( block >> 3 ) & ( ( 1 << 12 ) - 1 );
+    const auto codeword_lo = ( c0 >= c1 ) ? 1 : 0;
     const auto codeword = codeword_hi | codeword_lo;
 
     const uint32_t col_tab[] = {
-        clampu8(r0 + table59T58H[codeword]) | (clampu8(g0 + table59T58H[codeword]) << 8) | (clampu8(b0 + table59T58H[codeword]) << 16),
-        clampu8(r0 - table59T58H[codeword]) | (clampu8(g0 - table59T58H[codeword]) << 8) | (clampu8(b0 - table59T58H[codeword]) << 16),
-        clampu8(r1 + table59T58H[codeword]) | (clampu8(g1 + table59T58H[codeword]) << 8) | (clampu8(b1 + table59T58H[codeword]) << 16),
-        clampu8(r1 - table59T58H[codeword]) | (clampu8(g1 - table59T58H[codeword]) << 8) | (clampu8(b1 - table59T58H[codeword]) << 16)
+        clampu8( r0 + table59T58H[codeword] ) | ( clampu8( g0 + table59T58H[codeword] ) << 8 ) | ( clampu8( b0 + table59T58H[codeword] ) << 16 ),
+        clampu8( r0 - table59T58H[codeword] ) | ( clampu8( g0 - table59T58H[codeword] ) << 8 ) | ( clampu8( b0 - table59T58H[codeword] ) << 16 ),
+        clampu8( r1 + table59T58H[codeword] ) | ( clampu8( g1 + table59T58H[codeword] ) << 8 ) | ( clampu8( b1 + table59T58H[codeword] ) << 16 ),
+        clampu8( r1 - table59T58H[codeword] ) | ( clampu8( g1 - table59T58H[codeword] ) << 8 ) | ( clampu8( b1 - table59T58H[codeword] ) << 16 )
     };
 
-    for (uint8_t j = 0; j < 4; j++)
+    for( uint8_t j = 0; j < 4; j++ )
     {
-        for (uint8_t i = 0; i < 4; i++)
+        for( uint8_t i = 0; i < 4; i++ )
         {
-            const uint8_t index = (((indexes >> (j + i * 4 + 16)) & 0x1) << 1) | ((indexes >> (j + i * 4)) & 0x1);
+            const uint8_t index = ( ( ( indexes >> ( j + i * 4 + 16 ) ) & 0x1 ) << 1 ) | ( ( indexes >> ( j + i * 4 ) ) & 0x1 );
             dst[j * w + i] = col_tab[index] | 0xFF000000;
         }
     }
 }
 
-static etcpak_force_inline void DecodeHAlpha(uint64_t block, uint64_t alpha, uint32_t* dst, uint32_t w)
+static etcpak_force_inline void DecodeHAlpha( uint64_t block, uint64_t alpha, uint32_t* dst, uint32_t w )
 {
-    const uint32_t indexes = (block >> 32) & 0xFFFFFFFF;
+    const uint32_t indexes = ( block >> 32 ) & 0xFFFFFFFF;
 
-    const auto r0444 = (block >> 27) & 0xF;
-    const auto g0444 = ((block >> 20) & 0x1) | (((block >> 24) & 0x7) << 1);
-    const auto b0444 = ((block >> 15) & 0x7) | (((block >> 19) & 0x1) << 3);
+    const auto r0444 = ( block >> 27 ) & 0xF;
+    const auto g0444 = ( ( block >> 20 ) & 0x1 ) | ( ( ( block >> 24 ) & 0x7 ) << 1 );
+    const auto b0444 = ( ( block >> 15 ) & 0x7 ) | ( ( ( block >> 19 ) & 0x1 ) << 3 );
 
-    const auto r1444 = (block >> 11) & 0xF;
-    const auto g1444 = (block >> 7) & 0xF;
-    const auto b1444 = (block >> 3) & 0xF;
+    const auto r1444 = ( block >> 11 ) & 0xF;
+    const auto g1444 = ( block >> 7 ) & 0xF;
+    const auto b1444 = ( block >> 3 ) & 0xF;
 
-    const auto r0 = (r0444 << 4) | r0444;
-    const auto g0 = (g0444 << 4) | g0444;
-    const auto b0 = (b0444 << 4) | b0444;
+    const auto r0 = ( r0444 << 4 ) | r0444;
+    const auto g0 = ( g0444 << 4 ) | g0444;
+    const auto b0 = ( b0444 << 4 ) | b0444;
 
-    const auto r1 = (r1444 << 4) | r1444;
-    const auto g1 = (g1444 << 4) | g1444;
-    const auto b1 = (b1444 << 4) | b1444;
+    const auto r1 = ( r1444 << 4 ) | r1444;
+    const auto g1 = ( g1444 << 4 ) | g1444;
+    const auto b1 = ( b1444 << 4 ) | b1444;
 
-    const auto codeword_hi = ((block & 0x1) << 1) | ((block & 0x4) );
-    const auto c0 = (r0444 << 8) | (g0444 << 4) | (b0444 << 0);
-    const auto c1 = (block >> 3) & ((1 << 12) - 1);
-    const auto codeword_lo = (c0 >= c1) ? 1 : 0;
+    const auto codeword_hi = ( ( block & 0x1 ) << 1 ) | ( ( block & 0x4 ) );
+    const auto c0 = ( r0444 << 8 ) | ( g0444 << 4 ) | ( b0444 << 0 );
+    const auto c1 = ( block >> 3 ) & ( ( 1 << 12 ) - 1 );
+    const auto codeword_lo = ( c0 >= c1 ) ? 1 : 0;
     const auto codeword = codeword_hi | codeword_lo;
 
     const int32_t base = alpha >> 56;
-    const int32_t mul = (alpha >> 52) & 0xF;
+    const int32_t mul = ( alpha >> 52 ) & 0xF;
     const auto tbl = g_alpha[(alpha >> 48) & 0xF];
 
     const uint32_t col_tab[] = {
-        clampu8(r0 + table59T58H[codeword]) | (clampu8(g0 + table59T58H[codeword]) << 8) | (clampu8(b0 + table59T58H[codeword]) << 16),
-        clampu8(r0 - table59T58H[codeword]) | (clampu8(g0 - table59T58H[codeword]) << 8) | (clampu8(b0 - table59T58H[codeword]) << 16),
-        clampu8(r1 + table59T58H[codeword]) | (clampu8(g1 + table59T58H[codeword]) << 8) | (clampu8(b1 + table59T58H[codeword]) << 16),
-        clampu8(r1 - table59T58H[codeword]) | (clampu8(g1 - table59T58H[codeword]) << 8) | (clampu8(b1 - table59T58H[codeword]) << 16)
+        clampu8( r0 + table59T58H[codeword] ) | ( clampu8( g0 + table59T58H[codeword] ) << 8 ) | ( clampu8( b0 + table59T58H[codeword] ) << 16 ),
+        clampu8( r0 - table59T58H[codeword] ) | ( clampu8( g0 - table59T58H[codeword] ) << 8 ) | ( clampu8( b0 - table59T58H[codeword] ) << 16 ),
+        clampu8( r1 + table59T58H[codeword] ) | ( clampu8( g1 + table59T58H[codeword] ) << 8 ) | ( clampu8( b1 + table59T58H[codeword] ) << 16 ),
+        clampu8( r1 - table59T58H[codeword] ) | ( clampu8( g1 - table59T58H[codeword] ) << 8 ) | ( clampu8( b1 - table59T58H[codeword] ) << 16 )
     };
 
-    for (uint8_t j = 0; j < 4; j++)
+    for( uint8_t j = 0; j < 4; j++ )
     {
-        for (uint8_t i = 0; i < 4; i++)
+        for( uint8_t i = 0; i < 4; i++ )
         {
-            const uint8_t index = (((indexes >> (j + i * 4 + 16)) & 0x1) << 1) | ((indexes >> (j + i * 4)) & 0x1);
-            const auto amod = tbl[(alpha >> (45 - j * 3 - i * 12)) & 0x7];
-            const uint32_t a = clampu8(base + amod * mul);
-            dst[j * w + i] = col_tab[index] | (a << 24);
+            const uint8_t index = ( ( ( indexes >> ( j + i * 4 + 16 ) ) & 0x1 ) << 1 ) | ( ( indexes >> ( j + i * 4 ) ) & 0x1 );
+            const auto amod = tbl[( alpha >> ( 45 - j * 3 - i * 12) ) & 0x7];
+            const uint32_t a = clampu8( base + amod * mul );
+            dst[j * w + i] = col_tab[index] | ( a << 24 );
         }
     }
 }

--- a/BlockData.cpp
+++ b/BlockData.cpp
@@ -749,16 +749,16 @@ static etcpak_force_inline void DecodeRGBPart( uint64_t d, uint32_t* dst, uint32
         int32_t b1 = int32_t(b0) + db;
 
         // T mode
-        if ((r1 < 0) || (r1 > 31))
+        if ( (r1 < 0) || (r1 > 31) )
         {
-            DecodeT(d, dst, w);
+            DecodeT( d, dst, w );
             return;
         }
 
         // H mode
         if ((g1 < 0) || (g1 > 31))
         {
-            DecodeH(d, dst, w);
+            DecodeH( d, dst, w );
             return;
         }
 
@@ -886,23 +886,23 @@ static etcpak_force_inline void DecodeRGBAPart( uint64_t d, uint64_t alpha, uint
         int32_t b1 = int32_t(b0) + db;
 
         // T mode
-        if ((r1 < 0) || (r1 > 31))
+        if ( (r1 < 0) || (r1 > 31) )
         {
-            DecodeTAlpha(d, alpha, dst, w);
+            DecodeTAlpha( d, alpha, dst, w );
             return;
         }
 
         // H mode
-        if ((g1 < 0) || (g1 > 31))
+        if ( (g1 < 0) || (g1 > 31) )
         {
-            DecodeHAlpha(d, alpha, dst, w);
+            DecodeHAlpha( d, alpha, dst, w );
             return;
         }
 
         // P mode
-        if ((b1 < 0) || (b1 > 31))
+        if ( (b1 < 0) || (b1 > 31) )
         {
-            DecodePlanarAlpha(d, alpha, dst, w);
+            DecodePlanarAlpha( d, alpha, dst, w );
             return;
         }
 

--- a/BlockData.cpp
+++ b/BlockData.cpp
@@ -415,6 +415,49 @@ static etcpak_force_inline void DecodeTAlpha(uint64_t block, uint64_t alpha, uin
     }
 }
 
+static etcpak_force_inline void DecodeH(uint64_t block, uint32_t* dst, uint32_t w)
+{
+    const uint32_t indexes = (block >> 32) & 0xFFFFFFFF;
+
+    const auto r0444 = (block >> 27) & 0xF;
+    const auto g0444 = ((block >> 20) & 0x1) | (((block >> 24) & 0x7) << 1);
+    const auto b0444 = ((block >> 15) & 0x7) | (((block >> 19) & 0x1) << 3);
+
+    const auto r1444 = (block >> 11) & 0xF;
+    const auto g1444 = (block >> 7) & 0xF;
+    const auto b1444 = (block >> 3) & 0xF;
+
+    const auto r0 = (r0444 << 4) | r0444;
+    const auto g0 = (g0444 << 4) | g0444;
+    const auto b0 = (b0444 << 4) | b0444;
+
+    const auto r1 = (r1444 << 4) | r1444;
+    const auto g1 = (g1444 << 4) | g1444;
+    const auto b1 = (b1444 << 4) | b1444;
+
+    const auto codeword_hi = ((block & 0x1) << 1) | ((block & 0x4));
+    const auto c0 = (r0444 << 8) | (g0444 << 4) | (b0444 << 0);
+    const auto c1 = (block >> 3) & ((1 << 12) - 1);
+    const auto codeword_lo = (c0 >= c1) ? 1 : 0;
+    const auto codeword = codeword_hi | codeword_lo;
+
+    const uint32_t col_tab[] = {
+        clampu8(r0 + table59T58H[codeword]) | (clampu8(g0 + table59T58H[codeword]) << 8) | (clampu8(b0 + table59T58H[codeword]) << 16),
+        clampu8(r0 - table59T58H[codeword]) | (clampu8(g0 - table59T58H[codeword]) << 8) | (clampu8(b0 - table59T58H[codeword]) << 16),
+        clampu8(r1 + table59T58H[codeword]) | (clampu8(g1 + table59T58H[codeword]) << 8) | (clampu8(b1 + table59T58H[codeword]) << 16),
+        clampu8(r1 - table59T58H[codeword]) | (clampu8(g1 - table59T58H[codeword]) << 8) | (clampu8(b1 - table59T58H[codeword]) << 16)
+    };
+
+    for (uint8_t j = 0; j < 4; j++)
+    {
+        for (uint8_t i = 0; i < 4; i++)
+        {
+            const uint8_t index = (((indexes >> (j + i * 4 + 16)) & 0x1) << 1) | ((indexes >> (j + i * 4)) & 0x1);
+            dst[j * w + i] = col_tab[index] | 0xFF000000;
+        }
+    }
+}
+
 static etcpak_force_inline void DecodePlanar( uint64_t block, uint32_t* dst, uint32_t w )
 {
     const auto bv = expand6((block >> ( 0 + 32)) & 0x3F);
@@ -660,6 +703,13 @@ static etcpak_force_inline void DecodeRGBPart( uint64_t d, uint32_t* dst, uint32
         if ((r1 < 0) || (r1 > 31))
         {
             DecodeT(d, dst, w);
+            return;
+        }
+
+        // H mode
+        if ((g1 < 0) || (g1 > 31))
+        {
+            DecodeH(d, dst, w);
             return;
         }
 


### PR DESCRIPTION
This change adds support for blocks encoded in ETC2's T and H modes. Both RGB and RGBA are included.