### PR TITLE
Fix bswap definitions for MinGW (GCC and Clang)

### DIFF
--- a/BlockData.cpp
+++ b/BlockData.cpp
@@ -15,7 +15,7 @@
 #  include <arm_neon.h>
 #endif
 
-#ifdef __SSE4_1__
+#if defined __SSE4_1__ || defined __AVX2__ || defined _MSC_VER
 #  ifdef _MSC_VER
 #    include <intrin.h>
 #    include <Windows.h>
@@ -23,12 +23,6 @@
 #    define _bswap64(x) _byteswap_uint64(x)
 #  else
 #    include <x86intrin.h>
-#  endif
-#else
-#  ifndef _MSC_VER
-#    include <byteswap.h>
-#    define _bswap(x) bswap_32(x)
-#    define _bswap64(x) bswap_64(x)
 #  endif
 #endif
 

--- a/ProcessRGB.cpp
+++ b/ProcessRGB.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <string.h>
+#include <limits>
 
 #ifdef __ARM_NEON
 #  include <arm_neon.h>
@@ -20,12 +21,6 @@
 #    define _bswap64(x) _byteswap_uint64(x)
 #  else
 #    include <x86intrin.h>
-#  endif
-#else
-#  ifndef _MSC_VER
-#    include <byteswap.h>
-#    define _bswap(x) bswap_32(x)
-#    define _bswap64(x) bswap_64(x)
 #  endif
 #endif
 


### PR DESCRIPTION
`byteswap.h` is not available in MinGW (it's part of glibc), but the existing
fallback to `__builtin_bswap32`/`64` should work fine for both GCC and Clang
(on all platforms).

Also add missing `<limits>` include needed by GCC 10.

----

For context, we're integrating etcpak in the open source Godot game engine (work started by @fire), see https://github.com/godotengine/godot/pull/47370 for details.

We're really impressed with the performance boost that it gives us for ETC1/ETC2/DXT1/DXT5 encoding over our previous libraries etc2comp and squish.

The Godot editor supports most platforms (Windows, Linux, macOS, WebAssembly), including most popular compilation toolchains for these platforms. In particular, we use MinGW-GCC for our official Windows builds, and many contributors use [llvm-mingw](https://github.com/mstorsjo/llvm-mingw), so it's important for us to get this working.

Thankfully the required changes to support MinGW are minimal (I have a couple other small PRs coming), and we'll have it tested in production by thousands of users, so we can contribute necessary changes to ensure that etcpak is fully cross-platform.