### PR TITLE
Fix handling of pthread naming API for LLVM on Windows

### DIFF
--- a/System.cpp
+++ b/System.cpp
@@ -2,7 +2,6 @@
 #ifdef _WIN32
 #  include <windows.h>
 #else
-#  include <pthread.h>
 #  include <unistd.h>
 #endif
 
@@ -35,7 +34,7 @@ unsigned int System::CPUCores()
 
 void System::SetThreadName( std::thread& thread, const char* name )
 {
-#ifdef _WIN32
+#ifdef _MSC_VER
     const DWORD MS_VC_EXCEPTION=0x406D1388;
 
 #  pragma pack( push, 8 )
@@ -62,7 +61,5 @@ void System::SetThreadName( std::thread& thread, const char* name )
     __except(EXCEPTION_EXECUTE_HANDLER)
     {
     }
-#elif !defined(__APPLE__)
-    pthread_setname_np( thread.native_handle(), name );
 #endif
 }

--- a/TaskDispatch.cpp
+++ b/TaskDispatch.cpp
@@ -1,5 +1,8 @@
 #include <assert.h>
 #include <stdio.h>
+#ifndef _MSC_VER
+#include <pthread.h>
+#endif
 
 #include "Debug.hpp"
 #include "System.hpp"
@@ -22,15 +25,19 @@ TaskDispatch::TaskDispatch( size_t workers )
     {
         char tmp[16];
         sprintf( tmp, "Worker %zu", i );
-#ifdef __APPLE__
+#ifdef _MSC_VER
+        auto worker = std::thread( [this]{ Worker(); } );
+        System::SetThreadName( worker, tmp );
+#else // Using pthread.
         auto worker = std::thread( [this, tmp]{
+#  ifdef __APPLE__
             pthread_setname_np( tmp );
+#  else // Linux or MinGW.
+            pthread_setname_np( pthread_self(), tmp );
+#  endif
             Worker();
         } );
-#else
-        auto worker = std::thread( [this]{ Worker(); } );
 #endif
-        System::SetThreadName( worker, tmp );
         m_workers.emplace_back( std::move( worker ) );
     }
 


### PR DESCRIPTION
The previous two-step method relying on `std:thread:native_handle()` is tricky
as it's implementation-defined, and it seems that LLVM's libc++ does not return
a `pthread_t` handle even when using pthread (and the MSVC code path is not an
option for LLVM on Windows).

With mingw-gcc as packaged in Linux distros with pthread support it worked
fine, but with llvm-mingw it was problematic.
It seems like it could also be problematic with clang-cl.

Setting the name in the thread directly as done for Apple platforms is simpler
and should work fine.

Co-authored-by: @hpvb