### PR TITLE
Fix `-Wc++11-narrowing` errors with LLVM clang

### DIFF
--- a/BlockData.cpp
+++ b/BlockData.cpp
@@ -334,10 +334,10 @@ static etcpak_force_inline void DecodeT( uint64_t block, uint32_t* dst, uint32_t
     const auto c3b = clampu8( cb1 - table59T58H[codeword] );
 
     const uint32_t col_tab[4] = {
-        cr0 | ( cg0 << 8 ) | ( cb0 << 16 ) | 0xFF000000,
-        c2r | ( c2g << 8 ) | ( c2b << 16 ) | 0xFF000000,
-        cr1 | ( cg1 << 8 ) | ( cb1 << 16 ) | 0xFF000000,
-        c3r | ( c3g << 8 ) | ( c3b << 16 ) | 0xFF000000
+        uint32_t( cr0 | ( cg0 << 8 ) | ( cb0 << 16 ) | 0xFF000000 ),
+        uint32_t( c2r | ( c2g << 8 ) | ( c2b << 16 ) | 0xFF000000 ),
+        uint32_t( cr1 | ( cg1 << 8 ) | ( cb1 << 16 ) | 0xFF000000 ),
+        uint32_t( c3r | ( c3g << 8 ) | ( c3b << 16 ) | 0xFF000000 )
     };
 
     const uint32_t indexes = ( block >> 32 ) & 0xFFFFFFFF;
@@ -389,10 +389,10 @@ static etcpak_force_inline void DecodeTAlpha( uint64_t block, uint64_t alpha, ui
     const auto c3b = clampu8( cb1 - table59T58H[codeword] );
 
     const uint32_t col_tab[4] = {
-        cr0 | ( cg0 << 8 ) | ( cb0 << 16 ),
-        c2r | ( c2g << 8 ) | ( c2b << 16 ),
-        cr1 | ( cg1 << 8 ) | ( cb1 << 16 ),
-        c3r | ( c3g << 8 ) | ( c3b << 16 )
+        uint32_t( cr0 | ( cg0 << 8 ) | ( cb0 << 16 ) ),
+        uint32_t( c2r | ( c2g << 8 ) | ( c2b << 16 ) ),
+        uint32_t( cr1 | ( cg1 << 8 ) | ( cb1 << 16 ) ),
+        uint32_t( c3r | ( c3g << 8 ) | ( c3b << 16 ) )
     };
 
     const uint32_t indexes = ( block >> 32 ) & 0xFFFFFFFF;
@@ -436,10 +436,10 @@ static etcpak_force_inline void DecodeH( uint64_t block, uint32_t* dst, uint32_t
     const auto codeword = codeword_hi | codeword_lo;
 
     const uint32_t col_tab[] = {
-        clampu8( r0 + table59T58H[codeword] ) | ( clampu8( g0 + table59T58H[codeword] ) << 8 ) | ( clampu8( b0 + table59T58H[codeword] ) << 16 ),
-        clampu8( r0 - table59T58H[codeword] ) | ( clampu8( g0 - table59T58H[codeword] ) << 8 ) | ( clampu8( b0 - table59T58H[codeword] ) << 16 ),
-        clampu8( r1 + table59T58H[codeword] ) | ( clampu8( g1 + table59T58H[codeword] ) << 8 ) | ( clampu8( b1 + table59T58H[codeword] ) << 16 ),
-        clampu8( r1 - table59T58H[codeword] ) | ( clampu8( g1 - table59T58H[codeword] ) << 8 ) | ( clampu8( b1 - table59T58H[codeword] ) << 16 )
+        uint32_t( clampu8( r0 + table59T58H[codeword] ) | ( clampu8( g0 + table59T58H[codeword] ) << 8 ) | ( clampu8( b0 + table59T58H[codeword] ) << 16 ) ),
+        uint32_t( clampu8( r0 - table59T58H[codeword] ) | ( clampu8( g0 - table59T58H[codeword] ) << 8 ) | ( clampu8( b0 - table59T58H[codeword] ) << 16 ) ),
+        uint32_t( clampu8( r1 + table59T58H[codeword] ) | ( clampu8( g1 + table59T58H[codeword] ) << 8 ) | ( clampu8( b1 + table59T58H[codeword] ) << 16 ) ),
+        uint32_t( clampu8( r1 - table59T58H[codeword] ) | ( clampu8( g1 - table59T58H[codeword] ) << 8 ) | ( clampu8( b1 - table59T58H[codeword] ) << 16 ) )
     };
 
     for( uint8_t j = 0; j < 4; j++ )
@@ -483,10 +483,10 @@ static etcpak_force_inline void DecodeHAlpha( uint64_t block, uint64_t alpha, ui
     const auto tbl = g_alpha[(alpha >> 48) & 0xF];
 
     const uint32_t col_tab[] = {
-        clampu8( r0 + table59T58H[codeword] ) | ( clampu8( g0 + table59T58H[codeword] ) << 8 ) | ( clampu8( b0 + table59T58H[codeword] ) << 16 ),
-        clampu8( r0 - table59T58H[codeword] ) | ( clampu8( g0 - table59T58H[codeword] ) << 8 ) | ( clampu8( b0 - table59T58H[codeword] ) << 16 ),
-        clampu8( r1 + table59T58H[codeword] ) | ( clampu8( g1 + table59T58H[codeword] ) << 8 ) | ( clampu8( b1 + table59T58H[codeword] ) << 16 ),
-        clampu8( r1 - table59T58H[codeword] ) | ( clampu8( g1 - table59T58H[codeword] ) << 8 ) | ( clampu8( b1 - table59T58H[codeword] ) << 16 )
+        uint32_t( clampu8( r0 + table59T58H[codeword] ) | ( clampu8( g0 + table59T58H[codeword] ) << 8 ) | ( clampu8( b0 + table59T58H[codeword] ) << 16 ) ),
+        uint32_t( clampu8( r0 - table59T58H[codeword] ) | ( clampu8( g0 - table59T58H[codeword] ) << 8 ) | ( clampu8( b0 - table59T58H[codeword] ) << 16 ) ),
+        uint32_t( clampu8( r1 + table59T58H[codeword] ) | ( clampu8( g1 + table59T58H[codeword] ) << 8 ) | ( clampu8( b1 + table59T58H[codeword] ) << 16 ) ),
+        uint32_t( clampu8( r1 - table59T58H[codeword] ) | ( clampu8( g1 - table59T58H[codeword] ) << 8 ) | ( clampu8( b1 - table59T58H[codeword] ) << 16 ) )
     };
 
     for( uint8_t j = 0; j < 4; j++ )


### PR DESCRIPTION
Narrowing conversions from `int` to `uint32_t` and `unsigned long` to `uint32_t`.
The explicit cast silences the error.

Fixes the following type of errors from Clang 12.0 RC5 on Linux:
```
../BlockData.cpp:343:9: error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        cr0 | ( cg0 << 8 ) | ( cb0 << 16 ) | 0xFF000000,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:343:9: note: insert an explicit cast to silence this issue
        cr0 | ( cg0 << 8 ) | ( cb0 << 16 ) | 0xFF000000,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(                         )                                           
```

<details>
<summary>Full error output</summary>

```
../BlockData.cpp:343:9: error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        cr0 | ( cg0 << 8 ) | ( cb0 << 16 ) | 0xFF000000,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:343:9: note: insert an explicit cast to silence this issue
        cr0 | ( cg0 << 8 ) | ( cb0 << 16 ) | 0xFF000000,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(                         )                                                                                                                                                           
../BlockData.cpp:345:9: error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        cr1 | ( cg1 << 8 ) | ( cb1 << 16 ) | 0xFF000000,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:345:9: note: insert an explicit cast to silence this issue
        cr1 | ( cg1 << 8 ) | ( cb1 << 16 ) | 0xFF000000,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(                         )                                                                                                                                                           
../BlockData.cpp:398:9: error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        cr0 | ( cg0 << 8 ) | ( cb0 << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:398:9: note: insert an explicit cast to silence this issue
        cr0 | ( cg0 << 8 ) | ( cb0 << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(            )                                                                                                                                                                        
../BlockData.cpp:399:9: error: non-constant-expression cannot be narrowed from type 'int' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        c2r | ( c2g << 8 ) | ( c2b << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:399:9: note: insert an explicit cast to silence this issue
        c2r | ( c2g << 8 ) | ( c2b << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(            )                                                                                                                                                                        
../BlockData.cpp:400:9: error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        cr1 | ( cg1 << 8 ) | ( cb1 << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:400:9: note: insert an explicit cast to silence this issue
        cr1 | ( cg1 << 8 ) | ( cb1 << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(            )                                                                                                                                                                        
../BlockData.cpp:401:9: error: non-constant-expression cannot be narrowed from type 'int' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        c3r | ( c3g << 8 ) | ( c3b << 16 )
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:401:9: note: insert an explicit cast to silence this issue
        c3r | ( c3g << 8 ) | ( c3b << 16 )
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(            )                                                                                                                                                                        
../BlockData.cpp:445:9: error: non-constant-expression cannot be narrowed from type 'int' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        clampu8( r0 + table59T58H[codeword] ) | ( clampu8( g0 + table59T58H[codeword] ) << 8 ) | ( clampu8( b0 + table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:445:9: note: insert an explicit cast to silence this issue
        clampu8( r0 + table59T58H[codeword] ) | ( clampu8( g0 + table59T58H[codeword] ) << 8 ) | ( clampu8( b0 + table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(                                                                                                                  )                                                                  
../BlockData.cpp:446:9: error: non-constant-expression cannot be narrowed from type 'int' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        clampu8( r0 - table59T58H[codeword] ) | ( clampu8( g0 - table59T58H[codeword] ) << 8 ) | ( clampu8( b0 - table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:446:9: note: insert an explicit cast to silence this issue
        clampu8( r0 - table59T58H[codeword] ) | ( clampu8( g0 - table59T58H[codeword] ) << 8 ) | ( clampu8( b0 - table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(                                                                                                                  )                                                                  
../BlockData.cpp:447:9: error: non-constant-expression cannot be narrowed from type 'int' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        clampu8( r1 + table59T58H[codeword] ) | ( clampu8( g1 + table59T58H[codeword] ) << 8 ) | ( clampu8( b1 + table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:447:9: note: insert an explicit cast to silence this issue
        clampu8( r1 + table59T58H[codeword] ) | ( clampu8( g1 + table59T58H[codeword] ) << 8 ) | ( clampu8( b1 + table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(                                                                                                                  )                                                                  
../BlockData.cpp:448:9: error: non-constant-expression cannot be narrowed from type 'int' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        clampu8( r1 - table59T58H[codeword] ) | ( clampu8( g1 - table59T58H[codeword] ) << 8 ) | ( clampu8( b1 - table59T58H[codeword] ) << 16 )
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:448:9: note: insert an explicit cast to silence this issue
        clampu8( r1 - table59T58H[codeword] ) | ( clampu8( g1 - table59T58H[codeword] ) << 8 ) | ( clampu8( b1 - table59T58H[codeword] ) << 16 )
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(                                                                                                                  )                                                                  
../BlockData.cpp:492:9: error: non-constant-expression cannot be narrowed from type 'int' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        clampu8( r0 + table59T58H[codeword] ) | ( clampu8( g0 + table59T58H[codeword] ) << 8 ) | ( clampu8( b0 + table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:492:9: note: insert an explicit cast to silence this issue
        clampu8( r0 + table59T58H[codeword] ) | ( clampu8( g0 + table59T58H[codeword] ) << 8 ) | ( clampu8( b0 + table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(                                                                                                                  )                                                                  
../BlockData.cpp:493:9: error: non-constant-expression cannot be narrowed from type 'int' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        clampu8( r0 - table59T58H[codeword] ) | ( clampu8( g0 - table59T58H[codeword] ) << 8 ) | ( clampu8( b0 - table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:493:9: note: insert an explicit cast to silence this issue
        clampu8( r0 - table59T58H[codeword] ) | ( clampu8( g0 - table59T58H[codeword] ) << 8 ) | ( clampu8( b0 - table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(                                                                                                                  )                                                                  
../BlockData.cpp:494:9: error: non-constant-expression cannot be narrowed from type 'int' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        clampu8( r1 + table59T58H[codeword] ) | ( clampu8( g1 + table59T58H[codeword] ) << 8 ) | ( clampu8( b1 + table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:494:9: note: insert an explicit cast to silence this issue
        clampu8( r1 + table59T58H[codeword] ) | ( clampu8( g1 + table59T58H[codeword] ) << 8 ) | ( clampu8( b1 + table59T58H[codeword] ) << 16 ),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(                                                                                                                  )                                                                  
../BlockData.cpp:495:9: error: non-constant-expression cannot be narrowed from type 'int' to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
        clampu8( r1 - table59T58H[codeword] ) | ( clampu8( g1 - table59T58H[codeword] ) << 8 ) | ( clampu8( b1 - table59T58H[codeword] ) << 16 )
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../BlockData.cpp:495:9: note: insert an explicit cast to silence this issue
        clampu8( r1 - table59T58H[codeword] ) | ( clampu8( g1 - table59T58H[codeword] ) << 8 ) | ( clampu8( b1 - table59T58H[codeword] ) << 16 )
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        static_cast<uint32_t>(                                                                                                                  )
```

</details>

It's not only Clang though, GCC 10.3.0 gives me similar warnings, the only difference is that they're not treated as hard errors (unless using `-Werror`).

Whether this is the right way to solve the warning is for you to define, there might be other options to clarify the intent and avoid implicit narrowing conversions. CC @hpvb

Fixes #11.