### PR TITLE
Makefile: Fix include path for zlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ build/x64
 build/*sdf
 build/*.suo
 build/*.vcxproj.user
+unix/etcpak
 *.o
 *.d

--- a/unix/build.mk
+++ b/unix/build.mk
@@ -1,7 +1,7 @@
 CFLAGS += -DNO_GZIP -DPNG_INTEL_SSE
 CXXFLAGS := $(CFLAGS) -std=c++11
 DEFINES +=
-INCLUDES :=
+INCLUDES := -I../zlib
 LIBS := -lpthread
 IMAGE := etcpak
 


### PR DESCRIPTION
Marking this as draft as I did not look at the MSVC solution, so it might need further adjustments for MSVC.

The previous code did not include `../zlib` so libpng would fail building if `/usr/include/zlib.h` is not installed on Linux (unlikely for any user with a compiler, but still not a good practice to mix vendored and non-vendored dependencies).

For users who don't rely on the provided `Makefile` like us in Godot, this also allows unvendoring getopt, libpng, lz4, and zlib. In our use case we already vendor libpng and zlib ourselves so we don't need to include them again in etcpak - and we don't need getopt since we don't build `Application.cpp`. We do vendor lz4 still but the same logic applies as for libpng.