### PR TITLE
Add proper initialization of Luma fields

### DIFF
--- a/ProcessRGB.cpp
+++ b/ProcessRGB.cpp
@@ -44,7 +44,7 @@ struct Luma
     uint8_t minIdx = 255, maxIdx = 255;
     __m128i luma8;
 #else
-    uint8_t max, min, maxIdx, minIdx;
+    uint8_t max = 0, min = 255, maxIdx = 0, minIdx = 0;
     uint8_t val[16];
 #endif
 };


### PR DESCRIPTION
Values and indexes for min and max in scalar version were not initialized properly.