### PR TITLE
Fix invalid range for ARMv7 NEON lane intrinsics

### DIFF
--- a/ProcessRGB.cpp
+++ b/ProcessRGB.cpp
@@ -3216,9 +3216,9 @@ etcpak_force_inline static uint16x8_t ErrorProbe_EAC_NEON( uint8x8_t recVal, uin
     uint8x8_t srcValWide;
 #ifndef __aarch64__
     if( Index < 8 )
-        srcValWide = vdup_lane_u8( vget_low_u8( alphaBlock ), ClampConstant( Index, 0, 8 ) );
+        srcValWide = vdup_lane_u8( vget_low_u8( alphaBlock ), ClampConstant( Index, 0, 7 ) );
     else
-        srcValWide = vdup_lane_u8( vget_high_u8( alphaBlock ), ClampConstant( Index - 8, 0, 8 ) );
+        srcValWide = vdup_lane_u8( vget_high_u8( alphaBlock ), ClampConstant( Index - 8, 0, 7 ) );
 #else
     srcValWide = vdup_laneq_u8( alphaBlock, Index );
 #endif
@@ -3256,9 +3256,9 @@ etcpak_force_inline static int16x8_t WidenMultiplier_EAC_NEON( int16x8_t multipl
     constexpr int Lane = GetMulSel( Index );
 #ifndef __aarch64__
     if( Lane < 4 )
-        return vdupq_lane_s16( vget_low_s16( multipliers ), ClampConstant( Lane, 0, 4 ) );
+        return vdupq_lane_s16( vget_low_s16( multipliers ), ClampConstant( Lane, 0, 3 ) );
     else
-        return vdupq_lane_s16( vget_high_s16( multipliers ), ClampConstant( Lane - 4, 0, 4 ) );
+        return vdupq_lane_s16( vget_high_s16( multipliers ), ClampConstant( Lane - 4, 0, 3 ) );
 #else
     return vdupq_laneq_s16( multipliers, Lane );
 #endif


### PR DESCRIPTION
Compiling Etcpak for Android ARMv7 with NDK r23 would throw errors like this:
```
thirdparty/etcpak/ProcessRGB.cpp:3259:16: error: argument value 4 is outside the valid range
        return vdupq_lane_s16( vget_low_s16( multipliers ), ClampConstant( Lane, 0, 4 ) );
               ^                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/root/sdk/ndk/23.2.8568313/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/12.0.9/include/arm_neon.h:5979:14: note: expanded from macro 'vdupq_lane_s16'
  __ret_24 = splatq_lane_s16(__s0_24, __p1_24); \
             ^                        ~~~~~~~
/root/sdk/ndk/23.2.8568313/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/12.0.9/include/arm_neon.h:829:23: note: expanded from macro 'splatq_lane_s16'
  __ret = (int16x8_t) __builtin_neon_splatq_lane_v((int8x8_t)__s0, __p1, 1); \
                      ^                                            ~~~~
thirdparty/etcpak/ProcessRGB.cpp:3723:46: note: in instantiation of function template specialization 'WidenMultiplier_EAC_NEON<8>' requested here
    uint8x8_t recVals[16] = { EAC_APPLY_16X( EAC_RECONSTRUCT_VALUE ) };
                                             ^
```

These didn't happen with NDK r21, probably because this validation was added more
recently to Clang (possibly https://reviews.llvm.org/D74619).

I'm not familiar with NEON intrinsics but this looks like an off-by-one error introduced in d8be08eda71bf07dfa17d6fb3eefe71a8374101a, CC @hkr.

Related issue in Godot: https://github.com/godotengine/godot/issues/62516