### PR TITLE
Implement BC4 and BC5 compression

### DIFF
--- a/BlockData.hpp
+++ b/BlockData.hpp
@@ -22,7 +22,9 @@ public:
         Etc2_RGB,
         Etc2_RGBA,
         Dxt1,
-        Dxt5
+        Dxt5,
+        Bc4,
+        Bc5
     };
 
     BlockData( const char* fn );
@@ -42,6 +44,8 @@ private:
     etcpak_no_inline BitmapPtr DecodeRGBA();
     etcpak_no_inline BitmapPtr DecodeDxt1();
     etcpak_no_inline BitmapPtr DecodeDxt5();
+    etcpak_no_inline BitmapPtr DecodeBc4();
+    etcpak_no_inline BitmapPtr DecodeBc5();
 
     uint8_t* m_data;
     v2i m_size;

--- a/ProcessDxtc.cpp
+++ b/ProcessDxtc.cpp
@@ -739,18 +739,8 @@ static etcpak_force_inline uint64_t ProcessRGB_SSE( __m128i px0, __m128i px1, __
     return uint64_t( ( uint64_t( to565( vmin ) ) << 16 ) | to565( vmax ) | ( uint64_t( vp ) << 32 ) );
 }
 
-static etcpak_force_inline uint64_t ProcessAlpha_SSE( __m128i px0, __m128i px1, __m128i px2, __m128i px3 )
+static etcpak_force_inline uint64_t ProcessOneChannel_SSE( __m128i a )
 {
-    __m128i mask = _mm_setr_epi32( 0x0f0b0703, -1, -1, -1 );
-
-    __m128i m0 = _mm_shuffle_epi8( px0, mask );
-    __m128i m1 = _mm_shuffle_epi8( px1, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 3, 0, 3 ) ) );
-    __m128i m2 = _mm_shuffle_epi8( px2, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 0, 3, 3 ) ) );
-    __m128i m3 = _mm_shuffle_epi8( px3, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 0, 3, 3, 3 ) ) );
-    __m128i m4 = _mm_or_si128( m0, m1 );
-    __m128i m5 = _mm_or_si128( m2, m3 );
-    __m128i a = _mm_or_si128( m4, m5 );
-
     __m128i solidCmp = _mm_shuffle_epi8( a, _mm_setzero_si128() );
     __m128i cmpRes = _mm_cmpeq_epi8( a, solidCmp );
     if( _mm_testc_si128( cmpRes, _mm_set1_epi32( -1 ) ) )
@@ -799,6 +789,21 @@ static etcpak_force_inline uint64_t ProcessAlpha_SSE( __m128i px0, __m128i px1, 
         data |= idx << (i*6);
     }
     return (uint64_t)(uint16_t)_mm_cvtsi128_si32( minmax ) | ( data << 16 );
+}
+
+static etcpak_force_inline uint64_t ProcessAlpha_SSE( __m128i px0, __m128i px1, __m128i px2, __m128i px3 )
+{
+    __m128i mask = _mm_setr_epi32( 0x0f0b0703, -1, -1, -1 );
+
+    __m128i m0 = _mm_shuffle_epi8( px0, mask );
+    __m128i m1 = _mm_shuffle_epi8( px1, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 3, 0, 3 ) ) );
+    __m128i m2 = _mm_shuffle_epi8( px2, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 0, 3, 3 ) ) );
+    __m128i m3 = _mm_shuffle_epi8( px3, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 0, 3, 3, 3 ) ) );
+    __m128i m4 = _mm_or_si128( m0, m1 );
+    __m128i m5 = _mm_or_si128( m2, m3 );
+    __m128i a = _mm_or_si128( m4, m5 );
+
+    return ProcessOneChannel_SSE( a );
 }
 #endif
 
@@ -953,4 +958,129 @@ void CompressDxt5( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t w
 #endif
     }
     while( --blocks );
+}
+
+void CompressBc4( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width )
+{
+    int i = 0;
+    auto ptr = dst;
+    do
+    {
+#ifdef __SSE4_1__
+        __m128i px0 = _mm_loadu_si128( (__m128i*)( src + width * 0 ) );
+        __m128i px1 = _mm_loadu_si128( (__m128i*)( src + width * 1 ) );
+        __m128i px2 = _mm_loadu_si128( (__m128i*)( src + width * 2 ) );
+        __m128i px3 = _mm_loadu_si128( (__m128i*)( src + width * 3 ) );
+
+        src += 4;
+        if( ++i == width/4 )
+        {
+            src += width * 3;
+            i = 0;
+        }
+
+        __m128i mask = _mm_setr_epi32( 0x0c080400, -1, -1, -1 );
+
+        __m128i m0 = _mm_shuffle_epi8( px0, mask );
+        __m128i m1 = _mm_shuffle_epi8( px1, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 3, 0, 3 ) ) );
+        __m128i m2 = _mm_shuffle_epi8( px2, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 0, 3, 3 ) ) );
+        __m128i m3 = _mm_shuffle_epi8( px3, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 0, 3, 3, 3 ) ) );
+        __m128i m4 = _mm_or_si128( m0, m1 );
+        __m128i m5 = _mm_or_si128( m2, m3 );
+
+        *ptr++ = ProcessOneChannel_SSE( _mm_or_si128( m4, m5 ) );
+#else
+        uint8_t r[4*4];
+        auto rgba = src;
+        for( int i=0; i<4; i++ )
+        {
+            r[i*4] = rgba[0] & 0xff;
+            r[i*4+1] = rgba[1] & 0xff;
+            r[i*4+2] = rgba[2] & 0xff;
+            r[i*4+3] = rgba[3] & 0xff;
+
+            rgba += width;
+        }
+
+        src += 4;
+        if( ++i == width/4 )
+        {
+            src += width * 3;
+            i = 0;
+        }
+
+        *ptr++ = ProcessAlpha( r );
+#endif
+    } while( --blocks );
+}
+
+void CompressBc5( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width )
+{
+    int i = 0;
+    auto ptr = dst;
+    do
+    {
+#ifdef __SSE4_1__
+        __m128i px0 = _mm_loadu_si128( (__m128i*)( src + width * 0 ) );
+        __m128i px1 = _mm_loadu_si128( (__m128i*)( src + width * 1 ) );
+        __m128i px2 = _mm_loadu_si128( (__m128i*)( src + width * 2 ) );
+        __m128i px3 = _mm_loadu_si128( (__m128i*)( src + width * 3 ) );
+
+        src += 4;
+        if( ++i == width/4 )
+        {
+            src += width*3;
+            i = 0;
+        }
+
+        __m128i mask = _mm_setr_epi32( 0x0c080400, -1, -1, -1 );
+
+        __m128i m0 = _mm_shuffle_epi8( px0, mask );
+        __m128i m1 = _mm_shuffle_epi8( px1, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 3, 0, 3 ) ) );
+        __m128i m2 = _mm_shuffle_epi8( px2, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 0, 3, 3 ) ) );
+        __m128i m3 = _mm_shuffle_epi8( px3, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 0, 3, 3, 3 ) ) );
+        __m128i m4 = _mm_or_si128( m0, m1 );
+        __m128i m5 = _mm_or_si128( m2, m3 );
+
+        *ptr++ = ProcessOneChannel_SSE( _mm_or_si128( m4, m5 ) );
+
+        mask = _mm_setr_epi32( 0x0d090501, -1, -1, -1 );
+
+        m0 = _mm_shuffle_epi8( px0, mask );
+        m1 = _mm_shuffle_epi8( px1, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 3, 0, 3 ) ) );
+        m2 = _mm_shuffle_epi8( px2, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 0, 3, 3 ) ) );
+        m3 = _mm_shuffle_epi8( px3, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 0, 3, 3, 3 ) ) );
+        m4 = _mm_or_si128( m0, m1 );
+        m5 = _mm_or_si128( m2, m3 );
+
+        *ptr++ = ProcessOneChannel_SSE( _mm_or_si128( m4, m5 ) );
+#else
+        uint8_t rg[4*4*2];
+        auto rgba = src;
+        for( int i=0; i<4; i++ )
+        {
+            rg[i*4] = rgba[0] & 0xff;
+            rg[i*4+1] = rgba[1] & 0xff;
+            rg[i*4+2] = rgba[2] & 0xff;
+            rg[i*4+3] = rgba[3] & 0xff;
+
+            rg[16+i*4] = (rgba[0] & 0xff00) >> 8;
+            rg[16+i*4+1] = (rgba[1] & 0xff00) >> 8;
+            rg[16+i*4+2] = (rgba[2] & 0xff00) >> 8;
+            rg[16+i*4+3] = (rgba[3] & 0xff00) >> 8;
+
+            rgba += width;
+        }
+
+        src += 4;
+        if( ++i == width/4 )
+        {
+            src += width*3;
+            i = 0;
+        }
+
+        *ptr++ = ProcessAlpha( rg );
+        *ptr++ = ProcessAlpha( &rg[16] );
+#endif
+    } while( --blocks );
 }

--- a/ProcessDxtc.hpp
+++ b/ProcessDxtc.hpp
@@ -8,4 +8,7 @@ void CompressDxt1( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t w
 void CompressDxt1Dither( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width );
 void CompressDxt5( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width );
 
+void CompressBc4( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width );
+void CompressBc5( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width );
+
 #endif


### PR DESCRIPTION
This change adds support for compressing/decompressing BC4 and BC5 textures. By adding `--ronly` or `--rgonly` to the argument list with `--dxtc` the texture will be compressed as either BC4 or BC5.

Quality comparison:
| Original | BC4/BC5 | DXT1 | Diff (BC4/BC5 vs DXT1) |
|---------|-----------|-------|-------------------------|
|![pavement_normal](https://github.com/wolfpld/etcpak/assets/53150244/cfc67ec5-7a21-4309-ae09-177fc93ee013)|![inrg](https://github.com/wolfpld/etcpak/assets/53150244/c4030018-c8f2-43b9-8e4e-38fb0b7497d8)|![inrgb](https://github.com/wolfpld/etcpak/assets/53150244/b798ed2f-d83b-4a2c-8a2b-0fa50322f112)|![indiff](https://github.com/wolfpld/etcpak/assets/53150244/17e95ba2-a44e-4771-83b3-59f1b1c2064f)|
|![pavement_r](https://github.com/wolfpld/etcpak/assets/53150244/936d2b59-4d7c-4849-91f6-5d6b45d4c5f7)|![pvmt_r](https://github.com/wolfpld/etcpak/assets/53150244/c8112dd7-2afd-475a-b101-eb3a4641749c)|![pvmt_rgb](https://github.com/wolfpld/etcpak/assets/53150244/b71c67a1-4ec1-433e-8ccf-3c0973da5838)|![pvmt_diff](https://github.com/wolfpld/etcpak/assets/53150244/bd0bc8f2-8433-4eb0-b5d4-cd28d5e8e8ec)|


