### PR TITLE
Implement ETC2_R and ETC2_RG compression

### DIFF
--- a/Application.cpp
+++ b/Application.cpp
@@ -44,8 +44,8 @@ void Usage()
     fprintf( stderr, "  --rgba                 enable RGBA in ETC2 mode (RGB is used by default)\n" );
     fprintf( stderr, "  --disable-heuristics   disable heuristic selector of compression mode\n" );
     fprintf( stderr, "  --dxtc                 use BC1/BC3 compression\n" );
-    fprintf( stderr, "  --ronly                use Red channel compression (use with --dxtc for BC4)\n" );
-    fprintf( stderr, "  --rgonly               use RedGreen channel compression (use with --dxtc for BC5)\n" );
+    fprintf( stderr, "  --ronly                use Red channel compression (use with --dxtc for BC4, otherwise defaults to ETC2_R11)\n" );
+    fprintf( stderr, "  --rgonly               use RedGreen channel compression (use with --dxtc for BC5, otherwise defaults to ETC2_RG11)\n" );
     fprintf( stderr, "  --linear               input data is in linear space (disable sRGB conversion for mips)\n\n" );
     fprintf( stderr, "Output file name may be unneeded for some modes.\n" );
 }
@@ -227,7 +227,12 @@ int main( int argc, char** argv )
                     if( alpha ) channel = Channels::Alpha;
                     else channel = Channels::RGB;
                     if( rgba ) type = BlockData::Etc2_RGBA;
-                    else if( etc2 ) type = BlockData::Etc2_RGB;
+                    else if( etc2 )
+                    {
+                        if( ronly ) type = BlockData::Etc2_R11;
+                        else if( rgonly ) type = BlockData::Etc2_RG11;
+                        else type = BlockData::Etc2_RGB;
+                    }
                     else if( dxtc )
                     {
                         if( ronly ) type = BlockData::Bc4;
@@ -281,7 +286,12 @@ int main( int argc, char** argv )
                     if( alpha ) channel = Channels::Alpha;
                     else channel = Channels::RGB;
                     if( rgba ) type = BlockData::Etc2_RGBA;
-                    else if( etc2 ) type = BlockData::Etc2_RGB;
+                    else if( etc2 )
+                    {
+                        if( ronly ) type = BlockData::Etc2_R11;
+                        else if( rgonly ) type = BlockData::Etc2_RG11;
+                        else type = BlockData::Etc2_RGB;
+                    }
                     else if( dxtc )
                     {
                         if( ronly ) type = BlockData::Bc4;
@@ -330,13 +340,24 @@ int main( int argc, char** argv )
         BlockData::Type type;
         if( etc2 )
         {
-            if( rgba && dp.Alpha() )
+            if( ronly )
             {
-                type = BlockData::Etc2_RGBA;
+                type = BlockData::Etc2_R11;
+            }
+            else if( rgonly )
+            {
+                type = BlockData::Etc2_RG11;
             }
             else
             {
-                type = BlockData::Etc2_RGB;
+                if( rgba && dp.Alpha() )
+                {
+                    type = BlockData::Etc2_RGBA;
+                }
+                else
+                {
+                    type = BlockData::Etc2_RGB;
+                }
             }
         }
         else if( dxtc )

--- a/BlockData.hpp
+++ b/BlockData.hpp
@@ -21,6 +21,8 @@ public:
         Etc1,
         Etc2_RGB,
         Etc2_RGBA,
+        Etc2_R11,
+        Etc2_RG11,
         Dxt1,
         Dxt5,
         Bc4,
@@ -42,6 +44,8 @@ public:
 private:
     etcpak_no_inline BitmapPtr DecodeRGB();
     etcpak_no_inline BitmapPtr DecodeRGBA();
+    etcpak_no_inline BitmapPtr DecodeR();
+    etcpak_no_inline BitmapPtr DecodeRG();
     etcpak_no_inline BitmapPtr DecodeDxt1();
     etcpak_no_inline BitmapPtr DecodeDxt5();
     etcpak_no_inline BitmapPtr DecodeBc4();

--- a/ProcessRGB.cpp
+++ b/ProcessRGB.cpp
@@ -3266,16 +3266,21 @@ etcpak_force_inline static int16x8_t WidenMultiplier_EAC_NEON( int16x8_t multipl
 
 #endif
 
+template<bool checkSolid = true>
 static etcpak_force_inline uint64_t ProcessAlpha_ETC2( const uint8_t* src )
 {
 #if defined __SSE4_1__
-    // Check solid
     __m128i s = _mm_loadu_si128( (__m128i*)src );
-    __m128i solidCmp = _mm_set1_epi8( src[0] );
-    __m128i cmpRes = _mm_cmpeq_epi8( s, solidCmp );
-    if( _mm_testc_si128( cmpRes, _mm_set1_epi32( -1 ) ) )
+
+    if( checkSolid )
     {
-        return src[0];
+        // Check solid
+        __m128i solidCmp = _mm_set1_epi8( src[0] );
+        __m128i cmpRes = _mm_cmpeq_epi8( s, solidCmp );
+        if( _mm_testc_si128( cmpRes, _mm_set1_epi32( -1 ) ) )
+        {
+            return src[0];
+        }
     }
 
     // Calculate min, max
@@ -3684,12 +3689,15 @@ static etcpak_force_inline uint64_t ProcessAlpha_ETC2( const uint8_t* src )
     int srcMid;
     uint8x16_t srcAlphaBlock = vld1q_u8( src );
     {
-        uint8_t ref = src[0];
-        uint8x16_t a0 = vdupq_n_u8( ref );
-        uint8x16_t r = vceqq_u8( srcAlphaBlock, a0 );
-        int64x2_t m = vreinterpretq_s64_u8( r );
-        if( m[0] == -1 && m[1] == -1 )
-            return ref;
+        if( checkSolid )
+        {
+            uint8_t ref = src[0];
+            uint8x16_t a0 = vdupq_n_u8( ref );
+            uint8x16_t r = vceqq_u8( srcAlphaBlock, a0 );
+            int64x2_t m = vreinterpretq_s64_u8( r );
+            if( m[0] == -1 && m[1] == -1 )
+                return ref;
+        }
 
         // srcRange
 #ifdef __aarch64__
@@ -3759,6 +3767,7 @@ static etcpak_force_inline uint64_t ProcessAlpha_ETC2( const uint8_t* src )
 #undef EAC_RECONSTRUCT_VALUE
 
 #else
+    if( checkSolid )
     {
         bool solid = true;
         const uint8_t* ptr = src + 1;
@@ -3848,7 +3857,6 @@ static etcpak_force_inline uint64_t ProcessAlpha_ETC2( const uint8_t* src )
     return _bswap64( d );
 #endif
 }
-
 
 void CompressEtc1Alpha( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width )
 {
@@ -4176,8 +4184,148 @@ void CompressEtc2Rgba( const uint32_t* src, uint64_t* dst, uint32_t blocks, size
             src += width * 3;
             w = 0;
         }
-        *dst++ = ProcessAlpha_ETC2( alpha );
+        *dst++ = ProcessAlpha_ETC2<true>( alpha );
         *dst++ = ProcessRGB_ETC2( (uint8_t*)rgba, useHeuristics );
+    }
+    while( --blocks );
+}
+
+void CompressEacR( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width )
+{
+    int w = 0;
+    uint8_t r[4*4];
+    do
+    {
+#ifdef __SSE4_1__
+        __m128 px0 = _mm_castsi128_ps( _mm_loadu_si128( (__m128i*)( src + width * 0 ) ) );
+        __m128 px1 = _mm_castsi128_ps( _mm_loadu_si128( (__m128i*)( src + width * 1 ) ) );
+        __m128 px2 = _mm_castsi128_ps( _mm_loadu_si128( (__m128i*)( src + width * 2 ) ) );
+        __m128 px3 = _mm_castsi128_ps( _mm_loadu_si128( (__m128i*)( src + width * 3 ) ) );
+
+        _MM_TRANSPOSE4_PS( px0, px1, px2, px3 );
+
+        __m128i c0 = _mm_castps_si128( px0 );
+        __m128i c1 = _mm_castps_si128( px1 );
+        __m128i c2 = _mm_castps_si128( px2 );
+        __m128i c3 = _mm_castps_si128( px3 );
+
+        __m128i mask = _mm_setr_epi32( 0x0e0a0602, -1, -1, -1 );
+
+        __m128i a0 = _mm_shuffle_epi8( c0, mask );
+        __m128i a1 = _mm_shuffle_epi8( c1, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 3, 0, 3 ) ) );
+        __m128i a2 = _mm_shuffle_epi8( c2, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 0, 3, 3 ) ) );
+        __m128i a3 = _mm_shuffle_epi8( c3, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 0, 3, 3, 3 ) ) );
+
+        __m128i s0 = _mm_or_si128( a0, a1 );
+        __m128i s1 = _mm_or_si128( a2, a3 );
+        __m128i s2 = _mm_or_si128( s0, s1 );
+
+        _mm_store_si128( (__m128i*)r, s2 );
+
+        src += 4;
+#else
+        auto ptr8 = r;
+        for( int x=0; x<4; x++ )
+        {
+            auto v = *src;
+            *ptr8++ = (v & 0xff0000) >> 16;
+            src += width;
+            v = *src;
+            *ptr8++ = (v & 0xff0000) >> 16;
+            src += width;
+            v = *src;
+            *ptr8++ = (v & 0xff0000) >> 16;
+            src += width;
+            v = *src;
+            *ptr8++ = (v & 0xff0000) >> 16;
+            src -= width * 3 - 1;
+        }
+#endif
+        if( ++w == width/4 )
+        {
+            src += width * 3;
+            w = 0;
+        }
+        *dst++ = ProcessAlpha_ETC2<false>( r );
+    }
+    while( --blocks );
+}
+
+void CompressEacRg( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width )
+{
+    int w = 0;
+    uint8_t rg[4*4*2];
+    do
+    {
+#ifdef __SSE4_1__
+        __m128 px0 = _mm_castsi128_ps( _mm_loadu_si128( (__m128i*)( src + width * 0 ) ) );
+        __m128 px1 = _mm_castsi128_ps( _mm_loadu_si128( (__m128i*)( src + width * 1 ) ) );
+        __m128 px2 = _mm_castsi128_ps( _mm_loadu_si128( (__m128i*)( src + width * 2 ) ) );
+        __m128 px3 = _mm_castsi128_ps( _mm_loadu_si128( (__m128i*)( src + width * 3 ) ) );
+
+        _MM_TRANSPOSE4_PS( px0, px1, px2, px3 );
+
+        __m128i c0 = _mm_castps_si128( px0 );
+        __m128i c1 = _mm_castps_si128( px1 );
+        __m128i c2 = _mm_castps_si128( px2 );
+        __m128i c3 = _mm_castps_si128( px3 );
+
+        __m128i mask = _mm_setr_epi32( 0x0e0a0602, -1, -1, -1 );
+
+        __m128i r0 = _mm_shuffle_epi8( c0, mask );
+        __m128i r1 = _mm_shuffle_epi8( c1, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 3, 0, 3 ) ) );
+        __m128i r2 = _mm_shuffle_epi8( c2, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 0, 3, 3 ) ) );
+        __m128i r3 = _mm_shuffle_epi8( c3, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 0, 3, 3, 3 ) ) );
+
+        __m128i s0 = _mm_or_si128( r0, r1 );
+        __m128i s1 = _mm_or_si128( r2, r3 );
+        __m128i s2 = _mm_or_si128( s0, s1 );
+
+        _mm_store_si128( (__m128i*)rg, s2 );
+
+        mask = _mm_setr_epi32( 0x0d090501, -1, -1, -1 );
+
+        r0 = _mm_shuffle_epi8( c0, mask );
+        r1 = _mm_shuffle_epi8( c1, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 3, 0, 3 ) ) );
+        r2 = _mm_shuffle_epi8( c2, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 3, 0, 3, 3 ) ) );
+        r3 = _mm_shuffle_epi8( c3, _mm_shuffle_epi32( mask, _MM_SHUFFLE( 0, 3, 3, 3 ) ) );
+
+        s0 = _mm_or_si128( r0, r1 );
+        s1 = _mm_or_si128( r2, r3 );
+        s2 = _mm_or_si128( s0, s1 );
+
+        _mm_store_si128( (__m128i*)&rg[16], s2 );
+        src += 4;
+#else
+        auto ptrr = rg;
+        auto ptrg = ptrr + 16;
+        for( int x=0; x<4; x++ )
+        {
+            auto v = *src;
+            *ptrr++ = (v & 0xff0000) >> 16;
+            *ptrg++ = (v & 0xff00) >> 8;
+            src += width;
+            v = *src;
+            *ptrr++ = (v & 0xff0000) >> 16;
+            *ptrg++ = (v & 0xff00) >> 8;
+            src += width;
+            v = *src;
+            *ptrr++ = (v & 0xff0000) >> 16;
+            *ptrg++ = (v & 0xff00) >> 8;
+            src += width;
+            v = *src;
+            *ptrr++ = (v & 0xff0000) >> 16;
+            *ptrg++ = (v & 0xff00) >> 8;
+            src -= width * 3 - 1;
+        }
+#endif
+        if( ++w == width/4 )
+        {
+            src += width * 3;
+            w = 0;
+        }
+        *dst++ = ProcessAlpha_ETC2<false>( rg );
+        *dst++ = ProcessAlpha_ETC2<false>( &rg[16] );
     }
     while( --blocks );
 }

--- a/ProcessRGB.hpp
+++ b/ProcessRGB.hpp
@@ -10,4 +10,7 @@ void CompressEtc1RgbDither( const uint32_t* src, uint64_t* dst, uint32_t blocks,
 void CompressEtc2Rgb( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width, bool useHeuristics );
 void CompressEtc2Rgba( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width, bool useHeuristics );
 
+void CompressEacR( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width );
+void CompressEacRg( const uint32_t* src, uint64_t* dst, uint32_t blocks, size_t width );
+
 #endif

--- a/Tables.cpp
+++ b/Tables.cpp
@@ -86,6 +86,8 @@ const int32_t g_alpha[16][8] = {
     { -3, -5,  -7,  -9, 2, 4, 6,  8 }
 };
 
+const int32_t g_alpha11Mul[16] = { 1, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120 };
+
 const int32_t g_alphaRange[16] = {
     0x100FF / ( 1 + g_alpha[0][7] - g_alpha[0][3] ),
     0x100FF / ( 1 + g_alpha[1][7] - g_alpha[1][3] ),

--- a/Tables.hpp
+++ b/Tables.hpp
@@ -23,6 +23,7 @@ extern const uint32_t g_avg2[16];
 extern const uint32_t g_flags[64];
 
 extern const int32_t g_alpha[16][8];
+extern const int32_t g_alpha11Mul[16];
 extern const int32_t g_alphaRange[16];
 
 #ifdef __SSE4_1__


### PR DESCRIPTION
This change adds basic (8 bits per channel) support for EAC compression and decompression.
The R/RG modes are selected by default when using either of the `--ronly` or `--rgonly` flags without `--dxtc`.

Quality comparison:

| Original | ETC2_RGB | EAC | Diff (ETC2_RGB vs EAC) | Diff (EAC vs original) |
|---------|------------|------|------------------------|----------------------|
|![pavement_r](https://github.com/wolfpld/etcpak/assets/53150244/3f18d102-937f-493a-8cda-d834c0505eb8)|![r_rgb](https://github.com/wolfpld/etcpak/assets/53150244/ce7fd3b5-f965-4591-be82-6bdbdb43598f)|![r](https://github.com/wolfpld/etcpak/assets/53150244/da73e6e5-8e32-4056-bd44-88353f524847)|![r_diff](https://github.com/wolfpld/etcpak/assets/53150244/ad9e1679-668a-4b59-bcfb-77b9cdfd9106)|![r_ori_diff](https://github.com/wolfpld/etcpak/assets/53150244/8f71135e-7e34-4648-b47c-702525587ace)
|![pavement_normal](https://github.com/wolfpld/etcpak/assets/53150244/38ac0f1d-9ab6-456c-bb40-22978520c6fd)|![rg_rgb](https://github.com/wolfpld/etcpak/assets/53150244/6b5729be-c1ce-4621-a910-1a7a7467fd02)|![rg](https://github.com/wolfpld/etcpak/assets/53150244/59e780ae-62e9-42ee-9b7f-9a50b5bf14d6)|![rg_diff](https://github.com/wolfpld/etcpak/assets/53150244/754506cb-a3b2-4916-9ad4-a7b8a6e5bf0d)|![rg_ori_diff](https://github.com/wolfpld/etcpak/assets/53150244/4a49b748-08bb-4c5a-a02e-b66ba09428ca)|

