### PR TITLE
Fix non-power-of-two texture mip size

### DIFF
--- a/BlockData.cpp
+++ b/BlockData.cpp
@@ -327,7 +327,7 @@ static int AdjustSizeForMipmaps( const v2i& size, int levels )
         assert( current.x != 1 || current.y != 1 );
         current.x = std::max( 1, current.x / 2 );
         current.y = std::max( 1, current.y / 2 );
-        len += std::max( 4, current.x ) * std::max( 4, current.y ) / 2;
+        len += ( ( current.x + 3 ) & ~3 ) * ( ( current.y + 3 ) & ~3 ) / 2;
     }
     assert( current.x == 1 && current.y == 1 );
     return len;


### PR DESCRIPTION
Non-power-of-two textures eventually get a mip dimension that isn't divisible by 4; the length computation didn't properly round that to block boundaries.

Note: there is still some faulty logic in DataProvider.cpp that misbehaves for NPOT textures, so this doesn't fully fix the case when mips are generated; that would require a separate fix to the downsampling logic (ideally including masking off parts of the NPOT mips that are not used...)